### PR TITLE
Upgrade @aantron/repromise to reason-promise

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -4,7 +4,7 @@
   "bs-dependencies": [
     "reason-react",
     "bs-next",
-    "@aantron/repromise",
+    "reason-promise",
     "bs-webapi"
   ],
   "reason": { "react-jsx": 2 },

--- a/components/AddPlayer.re
+++ b/components/AddPlayer.re
@@ -43,7 +43,7 @@ let make = (~user: Types.user, _children) => {
           (
             self =>
               Firebase.addPlayer(~user, ~playerName, ~file)
-              |> Repromise.wait(() => self.send(UploadEnded))
+              ->Promise.get(() => self.send(UploadEnded))
           ),
         )
       | UploadEnded => ReasonReact.NoUpdate

--- a/components/Firebase.re
+++ b/components/Firebase.re
@@ -26,7 +26,7 @@ let onPlayerChanged = (user, onChange) =>
 [@bs.module "./firebase"]
 external addPlayer:
   (~user: Types.user, ~playerName: string, ~file: Types.file) =>
-  Repromise.t(unit) =
+  Promise.t(unit) =
   "";
 
 [@bs.module "./firebase"]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "deploy:production": "firebase use production && yarn build && firebase deploy -P production -m \"Commit: $(git rev-parse --short HEAD)\""
   },
   "dependencies": {
-    "@aantron/repromise": "^0.6.0",
     "bs-next": "^3.0.0",
     "bs-webapi": "^0.11.0",
     "firebase-admin": "~6.0.0",
@@ -23,10 +22,11 @@
     "react-dom": "^16.4.2",
     "react-konva": "^1.7.14",
     "react-motion": "^0.5.2",
+    "reason-promise": "^1.0.2",
     "reason-react": "^0.5.3"
   },
   "devDependencies": {
-    "bs-platform": "^4.0.5",
+    "bs-platform": "^7.0.1",
     "concurrently": "^3.6.1",
     "firebase-tools": "^4.2.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,6 @@
 # yarn lockfile v1
 
 
-"@aantron/repromise@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@aantron/repromise/-/repromise-0.6.0.tgz#45bea66e593b7e0f968bc0fd03f0b6578003e698"
-
 "@babel/code-frame@7.0.0-beta.42":
   version "7.0.0-beta.42"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.42.tgz#a9c83233fa7cd06b39dc77adbb908616ff4f1962"
@@ -1479,9 +1475,10 @@ bs-next@^3.0.0:
     next "^6.0.3"
     reason-react "^0.4.1"
 
-bs-platform@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-4.0.5.tgz#d4fd9bbdd11765af5b75110a5655065ece05eed6"
+bs-platform@^7.0.1:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.1.0.tgz#72b52148b1c4be7f878969e6e2afd1bfab068cdd"
+  integrity sha512-XUeZf1nGzmsVymG89j5L8G9YNDHl0J/5iDGExXA7a4RKxnbvP2TselBZAzFeEH4rs3gG01b7yKt+h2pm7yh7Ww==
 
 bs-webapi@^0.11.0:
   version "0.11.0"
@@ -5720,6 +5717,11 @@ readline2@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
+
+reason-promise@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/reason-promise/-/reason-promise-1.0.2.tgz#22b9bb4097ce511190182b948aef11427d5b8b86"
+  integrity sha512-j8DWV+71wNEKQmyW6zBOowIZq1Qec5CDWyLI37BvgOmAZgRFGFQ1MaJnbhqDe3JsYmaGyqdNMmpCJLl9EDbDAg==
 
 reason-react@^0.4.1:
   version "0.4.2"


### PR DESCRIPTION
Repromise became [**reason-promise**](https://github.com/aantron/promise) in 1.0.0. The API was renamed (e.g., `Repromise.wait` is now `Promise.get`), rearranged to prefer `->` instead of `|>`, and helpers were added for `Result` and `Option`, as well as some miscellaneous ones. The bundle size was reduced to 1K. See the [changelog](https://github.com/aantron/promise/releases/tag/1.0.0) here; there are also two subsequent bugfix releases.